### PR TITLE
Fix connection tester region

### DIFF
--- a/lambda/connection-tester.js
+++ b/lambda/connection-tester.js
@@ -50,7 +50,6 @@ exports.connect = function(event, context, callback) {
                 console.log('Error ending socket');
                 console.log(e);
             }
-            console.log('Destroying socket after timeout')
             socket.destroy();
             callback(null, {result: false});
         }, event.connectionTimeout_ms);

--- a/spec/LambdaConnectionTester.shouldReturnResult.spec.ts
+++ b/spec/LambdaConnectionTester.shouldReturnResult.spec.ts
@@ -6,29 +6,26 @@ var sinon = require('sinon')
 var AWSMock = require('aws-sdk-mock')
 
 describe("a connection testing example", ()=> {
-    let lambdaConnectionTester = new LambdaConnectionTester('ConnectionTestFunctionName')
+    let lambdaConnectionTester = new LambdaConnectionTester('ConnectionTestFunctionName', 'aws-region')
     let endpointAddress = {address : 'mythical.host', port: 31337}
-    let withMockedConnectionResult = (result) => {
-
-    }
 
     afterEach( () => {
         AWSMock.restore('Lambda')
     })
 
-    it("should return true when the lambda connection tester returns true",async () => {
+    it("should return true when the lambda connection tester returns true", async () => {
         AWSMock.mock('Lambda','invoke',callbackSuccessReturning(lambdaResponseData.successResult))
         let response = await lambdaConnectionTester.tryConnectionTo(endpointAddress)
         expect(response).toBe(true)
     })
 
-    it("should return false when the lambda connection tester returns false",async () => {
+    it("should return false when the lambda connection tester returns false", async () => {
         AWSMock.mock('Lambda','invoke',callbackSuccessReturning(lambdaResponseData.failureResult))
         let response = await lambdaConnectionTester.tryConnectionTo(endpointAddress)
         expect(response).toBe(false)
     })
 
-    it("should throw an Error when the lambda connection tester failed or timed out",async () => {
+    it("should throw an Error when the lambda connection tester failed or timed out", async () => {
         let msg = 'Lambda executionFailed'
         AWSMock.mock('Lambda','invoke',callbackFailure(msg))
         try {

--- a/src/ConnectionTesters/LambdaConnectionTester.ts
+++ b/src/ConnectionTesters/LambdaConnectionTester.ts
@@ -5,15 +5,17 @@ import { endpointAddress, connectionTester } from '../interfaces'
 export class LambdaConnectionTester implements connectionTester {
 
     lambdaFunctionName: string;
+    region: string;
 
-    constructor(lambdaFunctionName: string) {
+    constructor(lambdaFunctionName: string, region: string) {
         this.lambdaFunctionName = lambdaFunctionName;
+        this.region = region;
 
     }
 
     async tryConnectionTo(endpoint: endpointAddress, timeout_ms: number = 2000): Promise<boolean> {
         // Invoke the lambda by its function name
-        let lambda = new AwsLambda()
+        let lambda = new AwsLambda({ region: this.region })
         const lambdaParams = {
             FunctionName: this.lambdaFunctionName,
             InvocationType: "RequestResponse",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,6 @@ export { S3 }  from './S3'
 export {IAM} from './IAM'
 export {VPC} from './VPC'
 export {RDS} from './RDS'
+
+// All connection testers
+export * from './ConnectionTesters'


### PR DESCRIPTION
Add missing 'region' parameter from Lambda constructor
Export connection testers from module
