### PR TITLE
Create compliance test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,56 @@
 
 Beady Eye is a testing framework to support Behaviour Driven Infrastructure on AWS components, to keep an eye on your infrastructure compliance!
 
+# Getting Started
+
+Create your compliance test my-compliance-test.js:
+NOTE: compliance tests need to be `.js`
+```
+module.exports.suite = (params) => {
+    describe("My Redshift Cluster", () => {
+        let redshiftClusterName = 'my-redshift-cluster'
+
+        beforeAll((done)=> {
+        
+            const bdi = require('beady-eye')
+            const RedshiftCluster = bdi.RedshiftCluster
+            
+            this.redshift = new RedshiftCluster(redshiftClusterName, region)
+            done()
+        })
+
+        it("should exist", async (done) => {
+            expect(this.redshift).toBeDefined()
+            expect(await this.redshift.shouldExist()).toEqual(true)
+            done()
+        })
+    })
+}
+```
+
+Configure your src/complianceTestLambda.ts:
+```
+export const runCompliance: Handler = (event: APIGatewayEvent, context: Context, cb: Callback) => {
+
+  let complianceRunner = new JasmineComplianceRunner(cb)  
+
+  require('./my-compliance-test.js').suite(redshiftParams)
+
+  complianceRunner.execute()
+}
+```
+
+Configure serverless.yaml:
+```
+functions:
+  compliance:
+    handler: src/complianceTests.runCompliance
+    package:
+      include:
+        - src/*.js
+        - node_modules/beady-eye/**
+```
+
 # Development
 
 ```

--- a/package.json
+++ b/package.json
@@ -36,9 +36,13 @@
   "dependencies": {
     "aws-sdk": "^2.238.1",
     "chai": "^4.1.2",
-    "lodash.ismatch": "^4.4.0"
+    "lodash.ismatch": "^4.4.0",
+    "jasmine": "^3.1.0",
+    "jasmine-promise": "^0.0.1",
+    "jasmine-ts-console-reporter": "^3.1.1"
   },
   "devDependencies": {
+    "@types/aws-lambda": "^8.10.7",
     "@types/chai": "^4.1.3",
     "@types/jest": "^22.2.3",
     "@types/lodash.ismatch": "^4.4.3",
@@ -46,6 +50,7 @@
     "approvals": "^2.1.2",
     "aws-sdk-mock": "^2.0.0",
     "cloudformation-declarations": "^0.1.2",
+    "jasmine-ts": "^0.2.1",
     "jest": "^22.4.3",
     "nodemon": "^1.17.5",
     "snyk": "^1.80.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export { RedshiftCluster } from './Redshift'
 
 // All connection testers
 export * from './ConnectionTesters'
+export * from './runners/JasmineComplianceRunner'

--- a/src/runners/JasmineComplianceRunner.ts
+++ b/src/runners/JasmineComplianceRunner.ts
@@ -1,0 +1,74 @@
+import { APIGatewayEvent, Callback, Context, Handler } from 'aws-lambda';
+
+const Jasmine = require('jasmine')
+const TSConsoleReporter = require('jasmine-ts-console-reporter');
+
+export const lambdaNotificationReporter = (callback: Callback) => {
+  return {
+    results : [],
+    testErrors: [],
+    passedExpectations : [],
+    jasmineDone: function (result) {
+      if (result.overallStatus === 'failed') {
+        let failedTests = this.testErrors.map(x => x.fullName).join(',');
+        console.log(this.testErrors);
+        callback(new Error("tests failed:" + failedTests));
+      } else{
+        let passedTestCount = this.results.filter(x => x.status === 'passed').length
+        let testSummary = `Tests Passed: ${passedTestCount}`
+        this.passedExpectations.forEach((exp) => {
+          testSummary += exp.description; 
+        })
+        callback(null,testSummary);
+      }
+    },
+    specDone : function(result) {
+      this.results.push( result )
+      if (result.status !== 'passed') {
+        this.testErrors.push(result);
+        console.log(result.failedExpectations);
+      } 
+    },
+    suiteDone : function(result) {
+    //   console.log("SUITE DONE")
+    }
+  }
+}
+
+const defaultJasmineConfigurer = (jasmine) => {
+    let env = jasmine.env
+  
+    // env.fail
+    env.clearReporters(); // Clear default console reporter
+    env.specFilter = () => true
+    let reporter = new TSConsoleReporter()
+    reporter.setOptions( {showColor : false})
+    env.addReporter(reporter);
+    //  env.throwOnExpectationFailure(true)
+  
+}
+
+export class JasmineComplianceRunner {
+    jasmine
+    
+    constructor(callback: Callback) {
+        this.jasmine = new Jasmine()
+        
+        this.withConfigurer(defaultJasmineConfigurer)
+        
+        this.jasmine.env.addReporter(lambdaNotificationReporter(callback));
+        
+    }
+
+    /**
+     * Takes a callback function (jasmine) => {}, providing access to the underlying jasmine object for configuration
+     * @param jasmineConfigurer 
+     */
+    withConfigurer( jasmineConfigurer ){
+        jasmineConfigurer(this.jasmine)
+    }
+
+    execute() {
+        this.jasmine.env.execute()
+    }
+}

--- a/src/runners/JasmineComplianceRunner.ts
+++ b/src/runners/JasmineComplianceRunner.ts
@@ -10,7 +10,7 @@ export const lambdaNotificationReporter = (callback: Callback) => {
     passedExpectations : [],
     jasmineDone: function (result) {
       if (result.overallStatus === 'failed') {
-        let failedTests = this.testErrors.map(x => x.fullName).join(',');
+        let failedTests = this.testErrors.map(x => x.fullName).join(', ');
         console.log(this.testErrors);
         callback(new Error("tests failed:" + failedTests));
       } else{

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,9 @@
  "include": [
    "src",    
    "spec",
-   "src/*.js"
+   "lambda",
+   "src/*.js",
+   "lambda/*.js"
  ],
  "exclude": [
    "node_modules",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,10 @@
   dependencies:
     samsam "1.3.0"
 
+"@types/aws-lambda@^8.10.7":
+  version "8.10.7"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.7.tgz#1dfd0e1918205f74169658ad8aa8f9c06f161909"
+
 "@types/chai@^4.1.3":
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.3.tgz#b8a74352977a23b604c01aa784f5b793443fb7dc"
@@ -227,7 +231,7 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
 
-arrify@^1.0.1:
+arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
@@ -779,7 +783,7 @@ cliui@^2.1.0:
     right-align "^0.1.1"
     wordwrap "0.0.2"
 
-cliui@^3.0.3:
+cliui@^3.0.3, cliui@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
   dependencies:
@@ -1106,6 +1110,12 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
+error-stack-parser@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.2.tgz#4ae8dbaa2bf90a8b450707b9149dcabca135520d"
+  dependencies:
+    stackframe "^1.0.4"
+
 es-abstract@^1.5.1:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.11.0.tgz#cce87d518f0496893b1a30cd8461835535480681"
@@ -1367,7 +1377,7 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
-find-up@^2.1.0:
+find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
@@ -1527,7 +1537,7 @@ glob2base@^0.0.12:
   dependencies:
     find-index "^0.1.1"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -1675,6 +1685,12 @@ home-or-tmp@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
+
+homedir-polyfill@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
+  dependencies:
+    parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4:
   version "2.6.0"
@@ -2155,6 +2171,51 @@ istanbul-reports@^1.3.0:
   dependencies:
     handlebars "^4.0.3"
 
+jasmine-core@~2.99.0:
+  version "2.99.1"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.99.1.tgz#e6400df1e6b56e130b61c4bcd093daa7f6e8ca15"
+
+jasmine-core@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.1.0.tgz#a4785e135d5df65024dfc9224953df585bd2766c"
+
+jasmine-promise@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/jasmine-promise/-/jasmine-promise-0.0.1.tgz#916f6be5926bb1ad56e6ade0b0d3d396d2ff4dc9"
+
+jasmine-ts-console-reporter@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/jasmine-ts-console-reporter/-/jasmine-ts-console-reporter-3.1.1.tgz#86ce9a557f3073431130954b66c3c6bd77ce56ef"
+  dependencies:
+    error-stack-parser "^2.0.1"
+    minimatch "^3.0.4"
+    source-map "^0.5.7"
+    source-map-resolve "^0.5.0"
+
+jasmine-ts@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/jasmine-ts/-/jasmine-ts-0.2.1.tgz#7fe5911d98ea22cc257efe98f9728ab66ac0e90e"
+  dependencies:
+    jasmine "^2.6.0"
+    ts-node "^3.2.0"
+    typescript "^2.4.1"
+    yargs "^8.0.2"
+
+jasmine@^2.6.0:
+  version "2.99.0"
+  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-2.99.0.tgz#8ca72d102e639b867c6489856e0e18a9c7aa42b7"
+  dependencies:
+    exit "^0.1.2"
+    glob "^7.0.6"
+    jasmine-core "~2.99.0"
+
+jasmine@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-3.1.0.tgz#2bd59fd7ec6ec0e8acb64e09f45a68ed2ad1952a"
+  dependencies:
+    glob "^7.0.6"
+    jasmine-core "~3.1.0"
+
 jest-changed-files@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-22.4.3.tgz#8882181e022c38bd46a2e4d18d44d19d90a90fb2"
@@ -2591,6 +2652,15 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -2672,6 +2742,10 @@ make-dir@^1.0.0:
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
   dependencies:
     pify "^3.0.0"
+
+make-error@^1.1.1:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.4.tgz#19978ed575f9e9545d2ff8c13e33b5d18a67d535"
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -3191,6 +3265,10 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse-passwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
+
 parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
@@ -3242,6 +3320,12 @@ path-type@^1.0.0:
     graceful-fs "^4.1.2"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+path-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+  dependencies:
+    pify "^2.0.0"
 
 path@0.12.7:
   version "0.12.7"
@@ -3428,6 +3512,13 @@ read-pkg-up@^1.0.1:
     find-up "^1.0.0"
     read-pkg "^1.0.0"
 
+read-pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^2.0.0"
+
 read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
@@ -3435,6 +3526,14 @@ read-pkg@^1.0.0:
     load-json-file "^1.0.0"
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
+
+read-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
+  dependencies:
+    load-json-file "^2.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^2.0.0"
 
 readable-stream@1.1.x:
   version "1.1.14"
@@ -4021,7 +4120,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.4.15:
+source-map-support@^0.4.0, source-map-support@^0.4.15:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
   dependencies:
@@ -4108,6 +4207,10 @@ stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
 
+stackframe@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.0.4.tgz#357b24a992f9427cba6b545d96a14ed2cbca187b"
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -4173,7 +4276,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-bom@3.0.0:
+strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
@@ -4187,7 +4290,7 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
-strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -4392,6 +4495,28 @@ ts-jest@^22.4.6:
     source-map-support "^0.5.5"
     yargs "^11.0.0"
 
+ts-node@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-3.3.0.tgz#c13c6a3024e30be1180dd53038fc209289d4bf69"
+  dependencies:
+    arrify "^1.0.0"
+    chalk "^2.0.0"
+    diff "^3.1.0"
+    make-error "^1.1.1"
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
+    source-map-support "^0.4.0"
+    tsconfig "^6.0.0"
+    v8flags "^3.0.0"
+    yn "^2.0.0"
+
+tsconfig@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/tsconfig/-/tsconfig-6.0.0.tgz#6b0e8376003d7af1864f8df8f89dd0059ffcd032"
+  dependencies:
+    strip-bom "^3.0.0"
+    strip-json-comments "^2.0.0"
+
 tslib@^1.7.1:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.2.tgz#8be0cc9a1f6dc7727c38deb16c2ebd1a2892988e"
@@ -4416,7 +4541,7 @@ type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
-typescript@2.9.2:
+typescript@2.9.2, typescript@^2.4.1:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
 
@@ -4545,6 +4670,12 @@ uuid@3.1.0:
 uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
+
+v8flags@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.1.1.tgz#42259a1461c08397e37fe1d4f1cfb59cad85a053"
+  dependencies:
+    homedir-polyfill "^1.0.1"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.3"
@@ -4743,6 +4874,12 @@ yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
 
+yargs-parser@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs-parser@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
@@ -4801,6 +4938,24 @@ yargs@^3.19.0:
     window-size "^0.1.4"
     y18n "^3.2.0"
 
+yargs@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
+  dependencies:
+    camelcase "^4.1.0"
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    read-pkg-up "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^7.0.0"
+
 yargs@~3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"
@@ -4809,6 +4964,10 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yn@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
 
 zip@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Creates compliance runner for client use.

Considerations:
Opted to create a separate client class, rather than a lambda for consideration when loading specs, etc.  Options considered:
1. Lambda function loads specs passed in via the event, optionally including extra parameters for the suite
2. Suites passed as a callback to the Class constructor
3. *selected option* - client loads the suites after construction, but before execution.

Option 1 discounted, since when thinking from a security standpoint, this would allow for potentially arbitrary code execution within the compliance tests - since limited semantic validation could be applied to the loading of functions.

Option 2 discounted, since it would make initialising the suites more cumbersome.

Option 3, as demonstrated in the README.md, results in concise API for the client, whilst providing the flexibility for initialising the compliance suites.