### PR TITLE
RedshiftCluster should implement connectable

### DIFF
--- a/spec/Redshift/RedshiftCluster.externalEndpoint.spec.ts
+++ b/spec/Redshift/RedshiftCluster.externalEndpoint.spec.ts
@@ -30,8 +30,8 @@ describe("RedshiftCluster class", () => {
             it('should return the public endpoint details if the cluster exists', async (done) => {
                 let actual = await this.redshift.externalEndpoint()
 
-                expect(actual.Address).toBe("test-redshift-cluster.c7xqwt2jzuyc.ap-southeast-2.redshift.amazonaws.com")
-                expect(actual.Port).toBe(5439)
+                expect(actual.address).toBe("test-redshift-cluster.c7xqwt2jzuyc.ap-southeast-2.redshift.amazonaws.com")
+                expect(actual.port).toBe(5439)
                 done()
             })
         })

--- a/spec/Redshift/RedshiftCluster.getAddress.spec.ts
+++ b/spec/Redshift/RedshiftCluster.getAddress.spec.ts
@@ -7,12 +7,12 @@ describe("RedshiftCluster class", () => {
     let clusterName = "test-redshift-cluster"
     let region = 'ap-southeast-2'
 
-    describe('#externalEndpoint()', () => {
+    describe('#getAddress()', () => {
         
         it('should exist', async (done) => {
             AWSMock.mock('Redshift', 'describeClusters', awsMockCallback('test-data/redshift/describeClusters-exists.json'));
             this.redshift = new RedshiftCluster(clusterName, region)
-            expect(this.redshift.externalEndpoint).toBeDefined()
+            expect(this.redshift.getAddress).toBeDefined()
             done()
         })
 
@@ -28,10 +28,10 @@ describe("RedshiftCluster class", () => {
             })
 
             it('should return the public endpoint details if the cluster exists', async (done) => {
-                let actual = await this.redshift.externalEndpoint()
+                let actual = await this.redshift.getAddress()
 
-                expect(actual.Address).toBe("test-redshift-cluster.c7xqwt2jzuyc.ap-southeast-2.redshift.amazonaws.com")
-                expect(actual.Port).toBe(5439)
+                expect(actual.address).toBe("test-redshift-cluster.c7xqwt2jzuyc.ap-southeast-2.redshift.amazonaws.com")
+                expect(actual.port).toBe(5439)
                 done()
             })
         })
@@ -45,7 +45,7 @@ describe("RedshiftCluster class", () => {
 
             it('should fail', async (done) => {
                 try{
-                    let actual = await this.redshift.externalEndpoint()
+                    let actual = await this.redshift.getAddress()
                     fail("Error should have been thrown")
                 }catch(err){
                     expect(err.code).toBe("ClusterNotFound")

--- a/src/Redshift.ts
+++ b/src/Redshift.ts
@@ -1,10 +1,11 @@
 import { Redshift as AwsRedshift, EC2 } from 'aws-sdk'
 import { expect } from 'chai'
 import { region } from 'aws-sdk/clients/health';
+import { ConnectableAWSService } from './ConnectableAWSService'
 import { endpointAddress } from './interfaces'
 
 
-export class RedshiftCluster {
+export class RedshiftCluster extends ConnectableAWSService{
     clusterName: string
     redshiftClient: AwsRedshift
     ec2: EC2
@@ -42,8 +43,7 @@ export class RedshiftCluster {
         return allInboundCidrRanges.includes(cidrRange)
     }
 
-    async externalEndpoint(): Promise<endpointAddress>{
-
+    async getAddress(): Promise<endpointAddress> {
         let cluster = await this.getClusterDetails()
 
         expect(cluster.Endpoint).not.to.be.undefined
@@ -52,6 +52,24 @@ export class RedshiftCluster {
             address: cluster!.Endpoint!.Address as string,
             port: cluster!.Endpoint!.Port as number
         }
+    }
+
+
+    /**
+     * Get the endpoint for the RedshiftCluster
+     * @deprecated Use #getAddress() instead.  This method shall be removed in a future version.
+     * @see #getAddress
+     */
+    async externalEndpoint(): Promise<AwsRedshift.Endpoint>{
+
+        console.error('externalEndpoint is deprecated.')
+
+        let cluster = await this.getClusterDetails()
+
+        expect(cluster.Endpoint).not.to.be.undefined
+
+        return cluster!.Endpoint as AwsRedshift.Endpoint
+
     }
     
     private async getClusterDetails():Promise<AwsRedshift.Cluster> {

--- a/src/Redshift.ts
+++ b/src/Redshift.ts
@@ -1,6 +1,8 @@
 import { Redshift as AwsRedshift, EC2 } from 'aws-sdk'
 import { expect } from 'chai'
 import { region } from 'aws-sdk/clients/health';
+import { endpointAddress } from './interfaces'
+
 
 export class RedshiftCluster {
     clusterName: string
@@ -40,12 +42,16 @@ export class RedshiftCluster {
         return allInboundCidrRanges.includes(cidrRange)
     }
 
-    async externalEndpoint(): Promise<AwsRedshift.Endpoint>{
+    async externalEndpoint(): Promise<endpointAddress>{
 
         let cluster = await this.getClusterDetails()
 
         expect(cluster.Endpoint).not.to.be.undefined
-        return cluster!.Endpoint as AwsRedshift.Endpoint
+
+        return {
+            address: cluster!.Endpoint!.Address as string,
+            port: cluster!.Endpoint!.Port as number
+        }
     }
     
     private async getClusterDetails():Promise<AwsRedshift.Cluster> {

--- a/src/Redshift.ts
+++ b/src/Redshift.ts
@@ -2,10 +2,10 @@ import { Redshift as AwsRedshift, EC2 } from 'aws-sdk'
 import { expect } from 'chai'
 import { region } from 'aws-sdk/clients/health';
 import { ConnectableAWSService } from './ConnectableAWSService'
-import { endpointAddress } from './interfaces'
+import { endpointAddress, connectable } from './interfaces'
 
 
-export class RedshiftCluster extends ConnectableAWSService{
+export class RedshiftCluster implements connectable{
     clusterName: string
     redshiftClient: AwsRedshift
     ec2: EC2


### PR DESCRIPTION
At present, RedshiftCluster.endpointAddress returns `AWS.Redshift.Endpoint type`.

This has 2 problems:
* This creates a dependency on an external interface outside our control.  Whilst the chance of a breaking change is low, it's still undesirable
* More importantly, this return type is incompatible with the `endpointAddress` in `interfaces.ts`, making it incompatible with LambdaConnectionTester.

This PR refactors externalEndpoint to return interfaces.endpointAddress for consistency and applicability for LambdaConnectionTester.

At this time, RedshiftCluster does not implement ConnectableAWSService, since the parameters into the super class would require a breaking change (undesirable at this point).