### PR TITLE
Remove deferred pattern in favour of promisifying the callback

### DIFF
--- a/src/runners/JasmineComplianceRunner.ts
+++ b/src/runners/JasmineComplianceRunner.ts
@@ -1,45 +1,44 @@
-import { fakeReporter } from './fakeReporter';
-import * as Jasmine from 'jasmine';
-import * as TSConsoleReporter from 'jasmine-ts-console-reporter';
-
+import * as Jasmine from "jasmine";
+import * as TSConsoleReporter from "jasmine-ts-console-reporter";
+import { fakeReporter } from "./fakeReporter";
 
 export interface TestRunner {
-  execute(suite: Jasmine.suite): Promise<void>
+    execute(suite: Jasmine.suite): Promise<void>;
 }
 
 const defaultJasmineConfigurer = (jasmine) => {
-  let env = jasmine.env
-  env.clearReporters(); // Clear default console reporter
-  // Spec filter on env is deprecated
-  // env.specFilter = () => true
-  let reporter = new TSConsoleReporter()
-  reporter.setOptions({ showColor: false })
-  env.addReporter(reporter);
-}
+    const env = jasmine.env;
+    env.clearReporters(); // Clear default console reporter
+    // Spec filter on env is deprecated
+    // env.specFilter = () => true
+    const reporter = new TSConsoleReporter();
+    reporter.setOptions({ showColor: false });
+    env.addReporter(reporter);
+};
 
 export class JasmineComplianceRunner {
-  jasmine
-  private reportingCompleted: Promise<void>;
- 
-  constructor(...reporters: any[]) {
-    this.jasmine = new Jasmine()
-    this.withConfigurer(defaultJasmineConfigurer)
-    reporters.forEach(r => this.jasmine.env.addReporter(r));
-    const fakeRpt = fakeReporter()
-    this.jasmine.env.addReporter(fakeRpt.reporter);
-    this.reportingCompleted = fakeRpt.promise;
-  }
+    public jasmine;
+    private reportingCompleted: Promise<void>;
 
-  /**
-   * Takes a callback function (jasmine) => {}, providing access to the underlying jasmine object for configuration
-   * @param jasmineConfigurer 
-   */
-  withConfigurer(jasmineConfigurer) {
-    jasmineConfigurer(this.jasmine)
-  }
-  async execute(): Promise<void> {
-    this.jasmine.env.execute();
-    return this.reportingCompleted;
-  }
+    constructor(...reporters: any[]) {
+        this.jasmine = new Jasmine();
+        this.withConfigurer(defaultJasmineConfigurer);
+        reporters.forEach((r) => this.jasmine.env.addReporter(r));
+
+        this.reportingCompleted = new Promise((resolve, _) => {
+            this.jasmine.env.addReporter(fakeReporter(resolve));
+        });
+    }
+
+    /**
+     * Takes a callback function (jasmine) => {}, providing access to the underlying jasmine object for configuration
+     * @param jasmineConfigurer
+     */
+    public withConfigurer(jasmineConfigurer) {
+        jasmineConfigurer(this.jasmine);
+    }
+    public async execute(): Promise<void> {
+        this.jasmine.env.execute();
+        return this.reportingCompleted;
+    }
 }
-

--- a/src/runners/fakeReporter.ts
+++ b/src/runners/fakeReporter.ts
@@ -1,26 +1,8 @@
-class DeferredPromise {
-    resolve;
-    reject;
-    promise;
-  
-    constructor() {
-      this.promise = new Promise((resolve, reject)=> {
-        this.reject = reject
-        this.resolve = resolve
-      })
-    }
-}
-export const fakeReporter = () => {
-  const deferred = new DeferredPromise()
 
-  const reporter = {
-    jasmineDone: (_, done) => {
-      deferred.resolve()
-    }
-  }
-
-  return {
-    promise: deferred.promise,
-    reporter
-  }
-}
+export const fakeReporter = (callback) => {
+    return {
+        jasmineDone: (_, done) => {
+            callback();
+        },
+    };
+};


### PR DESCRIPTION
https://github.com/petkaantonov/bluebird/wiki/Promise-Anti-patterns

The deferred promise was one of my ideas - because I could not figure out how to return both the promise and the reporter object. After a couple of days of letting it float around my head I realized letting it take the callback and promisfying it made more sense, as the fakeReporter is never going to be handled directly by a user anyway.

FYI: @arullewis 